### PR TITLE
Fix Snake Movement Reversal Bug

### DIFF
--- a/coral.py
+++ b/coral.py
@@ -55,7 +55,6 @@ arena = pygame.display.set_mode((WIDTH, HEIGHT))
 
 # BIG_FONT   = pygame.font.Font("assets/font/Ramasuri.ttf", int(WIDTH/8))
 # SMALL_FONT = pygame.font.Font("assets/font/Ramasuri.ttf", int(WIDTH/20))
-
 BIG_FONT   = pygame.font.Font("assets/font/GetVoIP-Grotesque.ttf", int(WIDTH/8))
 SMALL_FONT = pygame.font.Font("assets/font/GetVoIP-Grotesque.ttf", int(WIDTH/20))
 
@@ -238,16 +237,16 @@ while True:
 
           # Key pressed
         if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_DOWN:    # Down arrow:  move down
+            if event.key == pygame.K_DOWN and snake.ymov == 0:    # Down arrow:  move down
                 snake.ymov = 1
                 snake.xmov = 0
-            elif event.key == pygame.K_UP:    # Up arrow:    move up
+            elif event.key == pygame.K_UP and snake.ymov == 0:    # Up arrow:    move up
                 snake.ymov = -1
                 snake.xmov = 0
-            elif event.key == pygame.K_RIGHT: # Right arrow: move right
+            elif event.key == pygame.K_RIGHT and snake.xmov == 0: # Right arrow: move right
                 snake.ymov = 0
                 snake.xmov = 1
-            elif event.key == pygame.K_LEFT:  # Left arrow:  move left
+            elif event.key == pygame.K_LEFT and snake.xmov == 0:  # Left arrow:  move left
                 snake.ymov = 0
                 snake.xmov = -1
             elif event.key == pygame.K_q:     # Q         : quit game

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -26,6 +26,7 @@
 
  __KNOWN BUGS__
 
+ # Corrigido
  * In the current implementation, reversing movement (e.g. if the snake moving
    right and the player press the left key), is not an illegal move, although
    a bad one, as it causes the snake to bite itself (this adds to the game


### PR DESCRIPTION
### **Problem:**

The bug occurred when the snake changed direction too quickly, causing it to reverse onto itself. This fix ensures that the snake cannot reverse its direction within a short time frame, improving gameplay responsiveness.