### PR TITLE
minor: update start menu and game over menu

### DIFF
--- a/coral.py
+++ b/coral.py
@@ -70,12 +70,23 @@ def center_prompt(title, subtitle):
     # Show title and subtitle.
 
     center_title = BIG_FONT.render(title, True, MESSAGE_COLOR)
-    center_title_rect = center_title.get_rect(center=(WIDTH/2, HEIGHT/2))
+    center_title_rect = center_title.get_rect(center=(WIDTH/2, HEIGHT/3))
     arena.blit(center_title, center_title_rect)
 
-    center_subtitle = SMALL_FONT.render(subtitle, True, MESSAGE_COLOR)
-    center_subtitle_rect = center_subtitle.get_rect(center=(WIDTH/2, HEIGHT*2/3))
-    arena.blit(center_subtitle, center_subtitle_rect)
+    # Split the subtitle into lines and adjust long text
+    wrapped_lines = []
+    max_chars_per_line = 30  # Adjust this value as needed to limit line length
+
+    # Break the subtitle into multiple lines, if necessary
+    for line in subtitle.split("\n"):
+        wrapped_lines.extend(textwrap.wrap(line, max_chars_per_line))
+
+    # Render each line
+    for i, line in enumerate(wrapped_lines):
+        center_subtitle = SMALL_FONT.render(line, True, MESSAGE_COLOR)
+        # Adjust the position of each line to appear one below the other
+        center_subtitle_rect = center_subtitle.get_rect(center=(WIDTH/2, HEIGHT/2 + i * (HEIGHT / 20)))
+        arena.blit(center_subtitle, center_subtitle_rect)
 
     pygame.display.update()
 

--- a/coral.py
+++ b/coral.py
@@ -21,6 +21,7 @@
 import pygame
 import random
 import sys
+import textwrap
 
 ##
 ## Game customization.
@@ -152,7 +153,7 @@ class Snake:
 
             # Tell the bad news
             pygame.draw.rect(arena, DEAD_HEAD_COLOR, snake.head)
-            center_prompt("Game Over", "Press to restart")
+            center_prompt("Game Over", "Press any key to restart.\nPress Q to quit the game.")
 
             # Respan the head
             self.x, self.y = GRID_SIZE, GRID_SIZE
@@ -232,7 +233,7 @@ snake = Snake()    # The snake
 
 apple = Apple()    # An apple
 
-center_prompt(WINDOW_TITLE, "Press to start")
+center_prompt(WINDOW_TITLE, "Press any key to start.\nPress P to pause the game.\nPress Q to quit the game.\nUse the arrow keys to move the snake")
 
 ##
 ## Main loop


### PR DESCRIPTION
Enhances the center_prompt function to handle long subtitle texts by breaking them into multiple lines for better readability.

- Adds logic to split subtitle text into multiple lines, with a configurable limit of 30 characters per line.
- Renders each line individually, spacing them vertically to ensure a clear and organized display.
- Retains event handling for start and quit functionality after the prompt is displayed.

These improvements prevent long messages from going off-screen, ensuring that all instructions remain visible and easy to read.