### PR TITLE
doc: add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,18 @@
  Follow these steps to set up and run the Coral Snake Game:
 
  ### Prerequisites
- 
- - Python 3: Make sure you have Python 3 installed on your machine. You can download it from the official Python website.
+
+ ### Prerequisites
+
+- Python 3: Make sure you have Python 3 installed on your machine.   
+  - Linux Users: You can use `apt` to install Python:  
+    ```bash
+    sudo apt update
+    sudo apt install python3
+    ```  
+    Note: The exact installation process may vary depending on your Linux distribution. Check your distribution's documentation if needed.  
+  
+  - Windows/Mac Users: You can download it from the official Python [website](https://www.python.org/downloads/).  
 
  - Pygame: The game requires the Pygame library, which can be installed using `pip` or other package managers like `pacman` on Arch Linux.
 
@@ -60,8 +70,8 @@
  First, clone the Coral repository to your local machine by running the following command in your terminal:
 
  ```bash
- git clone https://github.com/your-username/coral.git
- ```
+ git clone git@github.com:courselab/coral.git
+ ``` 
 
  2. Navigate to the project folder: Once the repository is cloned, navigate to the `coral` folder:
  

--- a/README.md
+++ b/README.md
@@ -41,3 +41,50 @@
  Your contribution will be greatly appreciated.
 
  See `docs/CONTRIBUTING.md` for further information.
+
+ Installation
+ ------------------------------
+
+ Follow these steps to set up and run the Coral Snake Game:
+
+ ### Prerequisites
+ 
+ - Python 3: Make sure you have Python 3 installed on your machine. You can download it from the official Python website.
+
+ - Pygame: The game requires the Pygame library, which can be installed using `pip` or other package managers like `pacman` on Arch Linux.
+
+ ### Installation Steps
+ 
+ 1. Clone the repository:
+
+ First, clone the Coral repository to your local machine by running the following command in your terminal:
+
+ ```bash
+ git clone https://github.com/your-username/coral.git
+ ```
+
+ 2. Navigate to the project folder: Once the repository is cloned, navigate to the `coral` folder:
+ 
+ ```bash
+ cd coral
+ ```
+
+ 3. Install dependencies: To install the required dependencies, you'll need to install Pygame. Run the following command:
+ 
+ - Using pip (recommended for most users):
+ 
+ ```bash
+ pip install pygame
+ ```
+
+ - Alternatively, if you're on an Arch-based system, you can install Pygame using pacman:
+
+ ```bash
+ sudo pacman -S python-pygame
+ ```
+
+ 4. Run the game: After installing Pygame, you can start the game by running the coral.py file. Run the following command:
+
+ ```bash
+ python coral.py
+ ```


### PR DESCRIPTION
This pull request addresses issue #77 by adding a new section to the README.md with installation instructions for the game. The instructions include:
- Prerequisites, such as Python 3 and the Pygame engine.
- Step-by-step guidance for installing Pygame, covering both pip and alternative package managers (e.g., pacman for Arch-based systems).
- Instructions on how to clone the repository, navigate to the project folder, and run the game using the coral.py file.

These additions aim to provide a clear and accessible guide for new developers or users unfamiliar with Python and Pygame, ensuring an easier setup process.