### PR TITLE
fixed respawn bug #71

### DIFF
--- a/coral.py
+++ b/coral.py
@@ -1,4 +1,4 @@
-!/usr/bin/python3
+#!/usr/bin/python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
 #   Copyright 2024 The Authors of Coral
@@ -18,10 +18,9 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pygame
 import random
 import sys
-
-import pygame
 
 ##
 ## Game customization.

--- a/coral.py
+++ b/coral.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+!/usr/bin/python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
 #   Copyright 2024 The Authors of Coral
@@ -18,9 +18,10 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pygame
 import random
 import sys
+
+import pygame
 
 ##
 ## Game customization.
@@ -416,6 +417,8 @@ class Snake:
 
             # Respan the head with initial directions
             self.x, self.y, self.xmov, self.ymov = random_position()
+            self.head.x = self.x
+            self.head.y = self.y
 
             self.draw_head()
 

--- a/coral.py
+++ b/coral.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+# !/usr/bin/python3
 #
 #   Copyright (c) 2023, Monaco F. J. <monaco@usp.br>
 #   Copyright 2024 The Authors of Coral
@@ -533,7 +533,6 @@ class Snake:
             
     # Draw stylized tail
     def draw_tail(self, tail, direction):
-        print(direction)
         # Define tail dimensions
         GRID_SIZE = size[configs[1]]
         tail_radius = GRID_SIZE // 3  # Smaller radius for the tail


### PR DESCRIPTION
Fixed a bug from Issue #71 where the snake died immediately after respawning from a death resulting from a wall collision. This was happening because on death, a new x and y coordinates were generated for the snake but head.x and head.y weren't updated accordingly. Fixed.