### PR TITLE
Feat/orange: fixed spawn rate and made the orange worth 2 points

### DIFF
--- a/coral.py
+++ b/coral.py
@@ -697,8 +697,7 @@ class Orange:
 
         # Check if the orange is already dropped, if not then maybe drop it
         if self.dropped == False:
-            #if random.randint(1, 100) >= 99:
-            if True:
+            if random.randint(1, 100) >= 99:
                 pygame.draw.circle(arena, ORANGE_COLOR, (self.rect.centerx, self.rect.centery), self.radius)
                 self.dropped = True
 


### PR DESCRIPTION
The spawn rate was mistakenly set to 100% every tick, which was not intended. This PR fixes that (to make it 2% every tick) and also makes the orange worth 2 points, rewarding the player for the increased difficulty.