### PR TITLE
Fix music not looping after resurrection

### DIFF
--- a/coral.py
+++ b/coral.py
@@ -505,7 +505,7 @@ class Snake:
             self.alive = True
             self.got_apple = False
             self.energy.set_max_energy()
-            pygame.mixer.music.play()
+            pygame.mixer.music.play(-1)
 
             # Drop an apple
             apple = Apple()


### PR DESCRIPTION
When the player dies, the music is played without the loop parameter, causing it to stop within ~50 seconds.
Fix'd #95 by passing the `-1` loop parameter to `pygame.music.play`.