### PR TITLE
Doc: Change name from KobraPy to Coral and fixed some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
  User instructions are available in the file `docs/manual.md`.
 
- If you're exploring KobraPy as a programming exercise, please refer to
+ If you're exploring Coral as a programming exercise, please refer to
  the file `docs/challenge.md` for directions. 
 
  And if you like it, feel free to let the author know.
@@ -46,8 +46,6 @@
  ------------------------------
 
  Follow these steps to set up and run the Coral Snake Game:
-
- ### Prerequisites
 
  ### Prerequisites
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Contributing to Coral
  Contribution workflow
  ------------------------------
 
- The official Coral repository is at https://github.com/monaco/kobrapy
+ The official Coral repository is at https://github.com/courselab/coral
    
  To start contributing, make sure you've read the essential documentation
  thoroughly:

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -49,7 +49,7 @@
 
 	  * the size of the grid
 	  * the snake speed
-   	  * the number of apples in the arena. 
+    * the number of apples in the arena. 
 	  * whether reversing the snake is allowed or not
 	  * whether apples disappear after some time
 	  * whether there may be poisoned apples that degrades energy

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -49,7 +49,7 @@
 
 	  * the size of the grid
 	  * the snake speed
-    * the number of apples in the arena. 
+   	  * the number of apples in the arena. 
 	  * whether reversing the snake is allowed or not
 	  * whether apples disappear after some time
 	  * whether there may be poisoned apples that degrades energy

--- a/docs/exercise-directions.md
+++ b/docs/exercise-directions.md
@@ -47,7 +47,7 @@
 
 	  * the size of the grid
 	  * the snake speed
-   	* the number of apples in the arena. 
+   	  * the number of apples in the arena. 
 	  * whether reversing the snake is allowed or not
 	  * whether apples disappear after some time
 	  * whether there may be poisoned apples that degrades energy

--- a/docs/exercise-directions.md
+++ b/docs/exercise-directions.md
@@ -47,7 +47,7 @@
 
 	  * the size of the grid
 	  * the snake speed
-   	  * the number of apples in the arena. 
+   	* the number of apples in the arena. 
 	  * whether reversing the snake is allowed or not
 	  * whether apples disappear after some time
 	  * whether there may be poisoned apples that degrades energy

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,8 +1,8 @@
 
- KobraPy Manual
+ Coral Manual
  ==============================
 
- KobraPy is intended as programming exercise.
+ Coral is intended as programming exercise.
 
  It consists in a very simple version of the classical 80s' arcade snake game
  written in Python, that is provided as an initial codebase  that should be 
@@ -10,7 +10,7 @@
  resource to teach open-source development practices, tools and project
  management methodologies to graduate computer sciences students.
 
- KobraPy is free software and can be distributed under the GNU General Public
+ Coral is free software and can be distributed under the GNU General Public
  License vr.3 or any later version.
 
  Requirements
@@ -44,14 +44,14 @@
 
  When the game ends, press any key to restart or 'q' to quit.
 
- Contributing to KobraPy
+ Contributing to Coral
  ------------------------------
 
- The official repository of KhobraPy is https://github.com/monacofj/khobrapy.
+ The official repository of Coral is https://github.com/courselab/coral.
 
  If you're willing to contribute to this project, suggestions are more than
  welcome.  Important information for contributing code can be found in the
  file `docs/CONTRIBUTING.md`. 
 
- Otherwise, if you're exploring KhobraPy as a programming exercise, please
+ Otherwise, if you're exploring Coral as a programming exercise, please
  refer to the file `docs/exercise-directions.md`.


### PR DESCRIPTION
Change documentation update the project name, mentioned on issue #113 

Did not change "KobraPy" to "Coral" on docs/challenge.md and docs/exercise-directions.md because it would not make sense in my opinion.