### PR TITLE
bug: Fixed Apple and Orange sizes to match the grid size

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -44,7 +44,7 @@ WINDOW_TITLE    = "Coral"  # Window title.
 MAX_QUEUE_SIZE = 3 # Movement queue max size
 
 velocity = [4, 7, 10,15]
-size = [60, 40, 20]  
+size = [50, 40, 25]
 n_apple = [1, 2, 3] 
 base_volume_levels = [0.4, 0.6, 0.7]
 volume_multiplier = [0.3, 1.1, 1.9]

--- a/app/main.py
+++ b/app/main.py
@@ -28,11 +28,11 @@ from app.orange import Orange
 from app.game import singleton_instance as gm
 
 
+gm.center_prompt(WINDOW_TITLE, "Press to start")
 gm.draw_grid()
 snake = Snake()    # The snake
 apple = Apple()    # An apple
 orange = Orange()  # An orange
-gm.center_prompt(WINDOW_TITLE, "Press to start")
 
 game_on = gm.game_on
 while True:


### PR DESCRIPTION
I fixed the issue by initializing and reading the configurations of the size of the board before initializing the snake, orange and apple objects.