### PR TITLE
fix issue #170: getting orange increases speed.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@
  The Authors of Cobra
  ==============================
 
+ * Caio Petroncini                  <caiopetroncini@usp.br>
  * Gabriela Rodrigues do Prado      <gabrielarprado@usp.br>
  * Guilherme de Abreu Barreto       <de_abreu@usp.br>
  * Jean Michel Furtado M'Peko       <furtado.jean@usp.br>

--- a/app/main.py
+++ b/app/main.py
@@ -18,17 +18,17 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pygame
 import sys
 
-from app.config import *
-from app.snake import Snake
-from app.apple import Apple
-from app.orange import Orange
-from app.game import singleton_instance as gm
-from app.translation import Translator
-from app.obstacles import Obstacle
+import pygame
 
+from app.apple import Apple
+from app.config import *
+from app.game import singleton_instance as gm
+from app.obstacles import Obstacle
+from app.orange import Orange
+from app.snake import Snake
+from app.translation import Translator
 
 gm.draw_grid()
 snake = Snake()  # The snake
@@ -69,7 +69,7 @@ while True:
                 instructions_shown = not instructions_shown
                 game_on = True
             elif key == pygame.K_SPACE:  # Increase speed
-                snake.speed = 2
+                snake.speed = 2.0
 
             # Movement controls (only if game is not paused or showing instructions)
             if game_on and not instructions_shown:
@@ -94,7 +94,7 @@ while True:
         # Key released
         if event.type == pygame.KEYUP:
             if event.key == pygame.K_SPACE:  # Go back to normal speed
-                snake.speed = 1
+                snake.speed = 1.0
 
     # Show instructions if the flag is set
     if instructions_shown:
@@ -133,6 +133,7 @@ while True:
         continue
 
     if game_on:
+        print(snake.speed)
         snake.update()
         gm.arena.fill(ARENA_COLOR)
         gm.draw_grid()
@@ -166,6 +167,7 @@ while True:
 
     # If the head passes over an orange, lengthen the snake and drop another orange
     if snake.head.x == orange.x and snake.head.y == orange.y:
+        snake.speed += 0.05
         orange = Orange()
         gm.got_apple_sound.play()
 

--- a/app/main.py
+++ b/app/main.py
@@ -133,7 +133,6 @@ while True:
         continue
 
     if game_on:
-        print(snake.speed)
         snake.update()
         gm.arena.fill(ARENA_COLOR)
         gm.draw_grid()

--- a/app/snake.py
+++ b/app/snake.py
@@ -19,10 +19,11 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import random
+
 import pygame
 
-from app.config import *
 from app.apple import Apple
+from app.config import *
 from app.energybar import EnergyBar
 from app.game import singleton_instance as gm
 
@@ -62,7 +63,7 @@ class Snake:
         self.move_queue = []
 
         # Multiplier based on number of collected oranges.
-        self.speed = 1
+        self.speed = 1.0
 
     # Add movement to movement queuedef
     def set_direction(self, xmov, ymov):
@@ -162,7 +163,7 @@ class Snake:
             gm.game_over_sound.stop()
             self.alive = True
             self.got_apple = False
-            self.speed = 1
+            self.speed = 1.0
             self.energy.set_max_energy()
             pygame.mixer.music.play()
 


### PR DESCRIPTION
Simple fix for issue #170 . Getting an orange wasn't increase the snake speed in v1.0.0. The line was removed at some point but the orange remained as a useless item that didnt do anything. Added the line for increasing snake speed by 0.04. Speed is reset upon death.