### PR TITLE
Fix music not looping after death (again...?) (#193)

### DIFF
--- a/app/snake.py
+++ b/app/snake.py
@@ -165,7 +165,7 @@ class Snake:
             self.got_apple = False
             self.speed = 1.0
             self.energy.set_max_energy()
-            pygame.mixer.music.play()
+            pygame.mixer.music.play(-1)
 
             # Drop an apple
             apple = Apple()


### PR DESCRIPTION
Not sure of what happened, but I'm having a déjà vu from this one... (#108).
Anyway, fix #193 by adding the loop flag to `pygame.mixer.music.play`.